### PR TITLE
Use headless Chrome as the browser engine for making requests, to avoid errors related to Javascript

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,5 +26,5 @@ const playstationType = {
         open(playstationType[choice].url);
     };
 
-    checkForPlaystationDirectRedirect(5000, onSuccess);
+    checkForPlaystationDirectRedirect(5000, onSuccess, playstationType[choice].id);
 })();

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 const open = require('open');
 const promptly = require('promptly');
+const puppeteer = require('puppeteer');
 
-const {checkForPlaystationDirectRedirect} = require("./utils");
+const { checkForPlaystationDirectRedirect } = require("./utils");
 
 /** Constants */
 let numTries = 1;
@@ -26,5 +27,5 @@ const playstationType = {
         open(playstationType[choice].url);
     };
 
-    checkForPlaystationDirectRedirect(5000, onSuccess, playstationType[choice].id);
+    checkForPlaystationDirectRedirect(5000, onSuccess, playstationType[choice].id, await puppeteer.launch());
 })();

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "open": "^7.3.0",
     "promptly": "^3.2.0",
     "puppeteer": "^5.5.0",
-    "puppeteer-core": "^5.5.0",
     "say": "^0.16.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "dependencies": {
     "axios": "^0.21.0",
     "open": "^7.3.0",
-    "promptly": "^3.2.0"
+    "promptly": "^3.2.0",
+    "puppeteer": "^5.5.0",
+    "puppeteer-core": "^5.5.0",
+    "say": "^0.16.0"
   },
   "devDependencies": {
     "jest": "^26.6.3"

--- a/utils.js
+++ b/utils.js
@@ -47,6 +47,8 @@ async function checkForPlaystationDirectRedirect(checkInterval, onSuccess, versi
 
     console.log(`Response status: ${responseStatus}`);
 
+    await context.close();
+
     // Uncomment to see the response body for debugging
     // console.log(`Response body: ${responseBody}`);
 

--- a/utils.js
+++ b/utils.js
@@ -1,4 +1,5 @@
 const axios = require('axios').default;
+const puppeteer = require('puppeteer');
 
 /** addToCartLoop 
  * Recursively tries to add a product to the cart
@@ -36,32 +37,35 @@ function addToCartLoop(id, guid, numTries, checkInterval = 10000) {
  * @param checkInterval - How often to check in ms
  * @param onSuccess - Callback function for successful redirect
  */
-async function checkForPlaystationDirectRedirect(checkInterval, onSuccess, numTries = 1) {
-    axios.get("https://direct.playstation.com/en-us/consoles/console/playstation5-console.3005816")
-        .then(response => {
-            if (response.data.indexOf("softblock") > 0) {
-                // They're sending us to reCAPTCHA, but it's not really the queue. Keep trying.
-                setTimeout(() => {
-                    console.log("No redirect detected. Trying again...");
-                    console.log("Number of tries", numTries);
-                    console.log("");
-                    numTries++;
+async function checkForPlaystationDirectRedirect(checkInterval, onSuccess, version, numTries = 1) {
+    // Fairly taxing, but we launch a new instance each time to make sure there's nothing
+    // cached that would prevent the queue from showing
+    const browser = await puppeteer.launch();
+    const page = await browser.newPage();
+    const url = `https://direct.playstation.com/en-us/consoles/console/playstation5-console.${version}`;
+    const response = await page.goto(url);
+    const responseBody = await response.text();
+    const responseStatus = await response.status();
+    const responseStatusText = await response.statusText();
 
-                    checkForPlaystationDirectRedirect(checkInterval, onSuccess, numTries);
-                }, checkInterval);
-            } else if (response.data.indexOf("queue-it_log") > 0) {
-                onSuccess();
-            } else {
-                setTimeout(() => {
-                    console.log("No redirect detected. Trying again...");
-                    console.log("Number of tries", numTries);
-                    console.log("");
-                    numTries++;
+    console.log(`Response status: ${responseStatus}`);
+    
+    // Uncomment to see the response body for debugging
+    // console.log(`Response body: ${responseBody}`);
 
-                    checkForPlaystationDirectRedirect(checkInterval, onSuccess, numTries);
-                }, checkInterval);
-            }
-        });
+    if (responseBody.indexOf("queue-it_log") > 0 && 
+        responseBody.indexOf("softblock") === -1) {
+        onSuccess();
+    } else {
+        setTimeout(() => {
+            console.log("No redirect detected. Trying again...");
+            console.log("Number of tries", numTries);
+            console.log("");
+            numTries++;
+
+            checkForPlaystationDirectRedirect(checkInterval, onSuccess, version, numTries);
+        }, checkInterval);
+    }
 }
 
 

--- a/utils.js
+++ b/utils.js
@@ -45,12 +45,11 @@ async function checkForPlaystationDirectRedirect(checkInterval, onSuccess, versi
     const responseBody = await response.text();
     const responseStatus = await response.status();
 
-    console.log(`Response status: ${responseStatus}`);
-
     await context.close();
 
     // Uncomment to see the response body for debugging
     // console.log(`Response body: ${responseBody}`);
+    // console.log(`Response status: ${responseStatus}`);
 
     if (responseBody.indexOf("queue-it_log") > 0 && 
         responseBody.indexOf("softblock") === -1) {

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,4 @@
 const axios = require('axios').default;
-const puppeteer = require('puppeteer');
 
 /** addToCartLoop 
  * Recursively tries to add a product to the cart
@@ -37,19 +36,17 @@ function addToCartLoop(id, guid, numTries, checkInterval = 10000) {
  * @param checkInterval - How often to check in ms
  * @param onSuccess - Callback function for successful redirect
  */
-async function checkForPlaystationDirectRedirect(checkInterval, onSuccess, version, numTries = 1) {
-    // Fairly taxing, but we launch a new instance each time to make sure there's nothing
-    // cached that would prevent the queue from showing
-    const browser = await puppeteer.launch();
-    const page = await browser.newPage();
+async function checkForPlaystationDirectRedirect(checkInterval, onSuccess, version, browser, numTries = 1) {
+    // Create a new incognito session each request to clear cookies and cache
+    const context = await browser.createIncognitoBrowserContext();
+    const page = await context.newPage();
     const url = `https://direct.playstation.com/en-us/consoles/console/playstation5-console.${version}`;
     const response = await page.goto(url);
     const responseBody = await response.text();
     const responseStatus = await response.status();
-    const responseStatusText = await response.statusText();
 
     console.log(`Response status: ${responseStatus}`);
-    
+
     // Uncomment to see the response body for debugging
     // console.log(`Response body: ${responseBody}`);
 
@@ -63,7 +60,7 @@ async function checkForPlaystationDirectRedirect(checkInterval, onSuccess, versi
             console.log("");
             numTries++;
 
-            checkForPlaystationDirectRedirect(checkInterval, onSuccess, version, numTries);
+            checkForPlaystationDirectRedirect(checkInterval, onSuccess, version, browser, numTries);
         }, checkInterval);
     }
 }


### PR DESCRIPTION
When creating requests using Axios as the engine, the site detects that Javascript is not enabled and returns an error. This set of changes does two things:
* Replaces Axios with Puppeteer (Chrome wrapper)
* Checks the page for the actual version you want for a queue to form, not hardcoding to the disc version. Before this change, potentially stock could drop on the digital version and not the disc version, and users looking for digital would never know.