### PR TITLE
Run onSuccess if cookie 'Queue-it' exists; change 'choose' to 'confirm' for wider range of y/n options (nit)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,14 +19,13 @@ const playstationType = {
 /** Let's do this */
 (async function() {
     const choice = await promptly.choose("Which version would you like? (disc or digital)", ["disc", "digital"]);
-    const alarm = await promptly.choose("Would you like to hear a loud, annoying alarm when we find your PS5? (Y or N)", ["Y", "N"])
+    const alarm = await promptly.confirm("Would you like to hear a loud, annoying alarm when we find your PS5? (Y or N)")
     console.log(`Searching for PlayStation 5 ${choice} edition...`);
-    
     const onSuccess = () => {
         console.log("Found it! Opening queue now...");
         open(playstationType[choice].url);
-        if (alarm.toUpperCase() === "Y") {
-            playAlarm();
+        if (alarm) {
+          playAlarm();
         }
     };
     checkForPlaystationDirectRedirect(5000, onSuccess, playstationType[choice].id, await puppeteer.launch());

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,9 +38,7 @@ function addToCartLoop(id, guid, numTries, checkInterval = 10000) {
  * @param onSuccess - Callback function for successful redirect
  */
 async function checkForPlaystationDirectRedirect(checkInterval, onSuccess, version, browser, numTries = 1) {
-    let response;
-    let responseBody;
-    let responseStatus;
+    let cookies, response, responseBody, responseStatus;
     const context = await browser.createIncognitoBrowserContext();
     const page = await context.newPage();
     const url = `https://direct.playstation.com/en-us/consoles/console/playstation5-console.${version}`;
@@ -49,6 +47,7 @@ async function checkForPlaystationDirectRedirect(checkInterval, onSuccess, versi
         response = await page.goto(url);
         responseBody = await response.text();
         responseStatus = await response.status();
+        cookies = await page.cookies();
     } catch(err) {
         console.log("Error connecting to PlayStation Direct store.");
     }
@@ -58,8 +57,8 @@ async function checkForPlaystationDirectRedirect(checkInterval, onSuccess, versi
     // console.log(`Response body: ${responseBody}`);
     // console.log(`Response status: ${responseStatus}`);
 
-    if (responseBody && responseBody.indexOf("queue-it_log") > 0 && 
-        responseBody.indexOf("softblock") === -1) {
+    if ((responseBody && responseBody.indexOf("queue-it_log") > 0 && 
+        responseBody.indexOf("softblock") === -1) || (cookies && cookies.length && cookies.some(cookie => cookie.name === 'Queue-it'))) {
         onSuccess();
     } else {
         setTimeout(() => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,7 +38,7 @@ function addToCartLoop(id, guid, numTries, checkInterval = 10000) {
  * @param onSuccess - Callback function for successful redirect
  */
 async function checkForPlaystationDirectRedirect(checkInterval, onSuccess, version, browser, numTries = 1) {
-    let cookies, response, responseBody, responseStatus;
+    let response, responseBody, responseStatus;
     const context = await browser.createIncognitoBrowserContext();
     const page = await context.newPage();
     const url = `https://direct.playstation.com/en-us/consoles/console/playstation5-console.${version}`;
@@ -47,7 +47,6 @@ async function checkForPlaystationDirectRedirect(checkInterval, onSuccess, versi
         response = await page.goto(url);
         responseBody = await response.text();
         responseStatus = await response.status();
-        cookies = await page.cookies();
     } catch(err) {
         console.log("Error connecting to PlayStation Direct store.");
     }
@@ -57,8 +56,8 @@ async function checkForPlaystationDirectRedirect(checkInterval, onSuccess, versi
     // console.log(`Response body: ${responseBody}`);
     // console.log(`Response status: ${responseStatus}`);
 
-    if ((responseBody && responseBody.indexOf("queue-it_log") > 0 && 
-        responseBody.indexOf("softblock") === -1) || (cookies && cookies.length && cookies.some(cookie => cookie.name === 'Queue-it'))) {
+    if (responseBody && responseBody.indexOf("queue-it_log") > 0 && 
+    responseBody.indexOf("softblock") === -1) {
         onSuccess();
     } else {
         setTimeout(() => {


### PR DESCRIPTION
Updated to run onSuccess if cookie 'Queue-it' exists. You can see this if you log responses from the API to console before and after drop.
Also changed 'choose' to 'confirm' for wider range of y/n options, now you can enter `'Y', 'y', '1'` for yes and `'N', 'n', '0'` for no