### PR TITLE
Use xdg-open instead of nvlc on Linux systems

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,7 @@ npm run watch
 ```
 3. You will be prompted which version (disc or digital) you would like to search for.
 
-4. You will be prompted if you'd like a loud, annoying alarm sound to play (more details on testing this below). If you are using linux, you'll need to have VLC installed to hear the alarm. Check your system for the binary `which nvlc`.
+4. You will be prompted if you'd like a loud, annoying alarm sound to play (more details on testing this below).
 
 5. Let it run in the background. Your browser will open up and direct you to the PlayStation Direct store as soon as stock is available.
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -81,7 +81,7 @@ function playAlarm() {
     } else if (os === "win32") {
         cmd.runSync("start ./src/assets/alarm.mp3");
     } else if (os === "linux") {
-        cmd.runSync("nvlc ./src/assets/alarm.mp3"); // Requires VLC to be installed
+        cmd.runSync("xdg-open ./src/assets/alarm.mp3");
     }
 }
 


### PR DESCRIPTION
`xdg-open` is more generic than `nvlc` and will open whatever is registered with the desktop environment for handling mp3 files (which could be VLC). This removes the dependency on VLC for Linux systems.

Tested on Solus Linux
Documentation indicates this should work on Debian/Ubuntu and Fedora (the package appears to be installed by default on systems that have DEs installed)